### PR TITLE
Add Software Engineering Daily and Toolsday

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 ## Front-End
 - *Responsive Design Podcast* - http://responsivedesign.is/podcast
 - *The SVG Immersion Podcast* - http://svgimmersion.com/
+- *Toolsday* - http://toolsday.io/
 
 
 ## Security & Performance

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 ## Interview Heavy
 - *Product People* - http://productpeople.tv
 - *ShopTalk* - http://shoptalkshow.com
+- *Software Engineering Daily* - http://softwareengineeringdaily.com/
 - *The Big Web Show* - http://5by5.tv/bigwebshow
 - *The Changelog* - http://5by5.tv/changelog
 - *The Non Breaking Space Show* - http://goodstuff.fm/nbsp


### PR DESCRIPTION
[Toolsday](http://toolsday.io) is a front end development podcast which focuses on the tools used by FEDs.
[Software Engineering Daily](http://softwareengineeringdaily.com) is a mostly interview-based podcast which discusses lots of different engineering topics.
