### PR TITLE
adds Python Podcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,7 @@
 
 ## Mobile Dev
 - *React Native Radio* - https://devchat.tv/react-native-radio
+
+## Python
+- *Talk Python To Me* - https://talkpython.fm/
+- *Python Bytes* - https://pythonbytes.fm/


### PR DESCRIPTION
This PR adds the two Podcasts "Talk Python To Me"  and "Python Bytes"

Both Podcasts are heavily Python related.

[**Python Bytes**](https://pythonbytes.fm/) takes Python News and Headlines of a given Week and compiles them to a usually 20-30 Minutes long Podcast.

[**Talk Python To Me**](https://talkpython.fm/) Is a Interview based Podcast in which the Host Michael Kennedy Talks to Developer and People in the Industry using Python.
I can i.e. recommend these Episode:
- [Openstack Cloud Computing built on Python](https://talkpython.fm/episodes/show/33/openstack-cloud-computing-built-on-python)
- [Python at Netflix](https://talkpython.fm/episodes/show/16/python-at-netflix)
- [Contributing to Open Source](https://talkpython.fm/episodes/show/132/contributing-to-open-source)
