### PR TITLE
Adds Masters of Scale to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - *The Changelog* - http://5by5.tv/changelog
 - *Three Devs and a Maybe* - http://threedevsandamaybe.com
 - *Master Mind* - http://mastermind.fm
+- *Masters of Scale* - https://mastersofscale.com/
 
 ## Front-End
 - *Toolsday* - http://toolsday.io


### PR DESCRIPTION
Masters of Scale is a podcast hosted by Reid Hoffman, co-founder of LinkedIn and investor at Greylock. He interviews great leaders from tech companies and ask them about their path scaling their products.